### PR TITLE
PA-331: Using Key Hash as Key Name in api path

### DIFF
--- a/src/cmd/serve.go
+++ b/src/cmd/serve.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -73,7 +72,6 @@ var serveCmd = &cobra.Command{
 
 		// Run Signer server
 		if mode == defaultMode {
-
 			api.RunSignerServer(map[string]interface{}{
 				"keys": keys,
 			})


### PR DESCRIPTION
Making calling an endpoint instead of using only hard-coded arbitrary key names like k1, k2.

Now we can dynamically set the key hash as the endpoint , e.g. :

` api/sign/k1` 
` api/sign/KEY_HASH`